### PR TITLE
fix: Request for blank flashcards to have more space for gloss

### DIFF
--- a/Burmese_blank_flashcards.htm
+++ b/Burmese_blank_flashcards.htm
@@ -64,8 +64,8 @@
             </div>
             <div class="row g-0">
               <div class="col-12 text-center rounded border-start border-end border-bottom border-primary">
-                <p class="fs-3"> </p>
-                <p class="fs-5 lh-1"> </p>
+                <p class="fs-3"><br></p>
+                <p class="fs-5 lh-1"><br></p>
                 <p class="fs-7 lh-1">#</p>
               </div>
             </div>
@@ -121,8 +121,8 @@
             </div>
             <div class="row g-0">
               <div class="col-12 text-center rounded border-start border-end border-bottom border-primary">
-                <p class="fs-3"> </p>
-                <p class="fs-5 lh-1"> </p>
+                <p class="fs-3"><br></p>
+                <p class="fs-5 lh-1"><br></p>
                 <p class="fs-7 lh-1">#</p>
               </div>
             </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,8 @@ tsv.forEach((f, index) => {
 
 // Generate blank flashcards
 let blank : config.configType = {
-  english: ' ',
-  lwc: ' ',
+  english: '<br>',
+  lwc: '<br>',
   pos: config.PoS.I,
   ipa: ' '
 }


### PR DESCRIPTION
User request for the blank flashcards to have more space at the bottom for gloss entries